### PR TITLE
fix: clarify location info

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,7 +100,7 @@
     <section id="location">
       <h2>Location</h2>
       <p>
-        We're aiming to have the 2024 Ruby Unconf at the
+        The 2024 Ruby Unconf is back at 
         <a href="https://www.haw-hamburg.de/" target="_blank">HAW Hamburg Finkenau</a> again.
         (<a href="https://www.openstreetmap.org/directions?from=&amp;to=53.56922%2C10.03495#map=19/53.56909/10.03470" target="_blank">Finkenau 35, 22081 Hamburg, Germany</a>)
       </p>


### PR DESCRIPTION
It was pointed out on mastodon that our location info phrasing is unclear